### PR TITLE
full path refs

### DIFF
--- a/AutopilotBranding/Make.cmd
+++ b/AutopilotBranding/Make.cmd
@@ -3,5 +3,5 @@ rmdir obj\Debug /s /q
 rmdir bin\Debug /s /q
 
 :: Compile and link
-"%Wix%\bin\candle.exe" -out obj\Debug\ -ext ..\packages\PowerShellWixExtension.2.0.1\tools\lib\PowerShellWixExtension.dll Product.wxs
-"%Wix%\bin\light.exe" -out bin\Debug\AutopilotBranding.msi -ext ..\packages\PowerShellWixExtension.2.0.1\tools\lib\PowerShellWixExtension.dll obj\Debug\Product.wixobj
+"%Wix%\bin\candle.exe" -out obj\Debug\ -ext "%ProgramFiles%\PackageManagement\NuGet\Packages\PowerShellWixExtension.2.0.1\tools\lib\PowerShellWixExtension.dll" Product.wxs
+"%Wix%\bin\light.exe" -out bin\Debug\AutopilotBranding.msi -ext "%ProgramFiles%\PackageManagement\NuGet\Packages\PowerShellWixExtension.2.0.1\tools\lib\PowerShellWixExtension.dll" obj\Debug\Product.wixobj


### PR DESCRIPTION
Replaced ".." with "C:\Program Files\PackageManagement\NuGet\" to allow for AutopilotBranding folder to be independent of Wix install location.