### PR TITLE
Change Set-TimeZone to use -Id parameter

### DIFF
--- a/AutopilotBranding/Branding.ps1
+++ b/AutopilotBranding/Branding.ps1
@@ -25,7 +25,7 @@ reg.exe unload HKLM\TempUser | Out-Host
 # STEP 3: Set time zone (if specified)
 if ($config.Config.TimeZone) {
 	Write-Host "Setting time zone: $($config.Config.TimeZone)"
-	Set-Timezone -Name $config.Config.TimeZone
+	Set-Timezone -Id $config.Config.TimeZone
 }
 
 # STEP 4: Remove specified provisioned apps if they exist


### PR DESCRIPTION
When using non english base OS names of timezones are different than in English OS and Set-TimeZone step fails and the script does not continue. Using -Id parameter ensures that script should work independant of base OS language.