### PR TITLE
Support for Disabling Features and Removing FODs

### DIFF
--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -65,6 +65,10 @@ reg.exe add "HKLM\TempUser\Software\Microsoft\Windows\CurrentVersion\Explorer\Ad
 # STEP 2B: Hide "Learn more about this picture" from the desktop
 reg.exe add "HKLM\TempUser\Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel" /v "{2cc5ca98-6485-489a-920e-b3e88a6ccce3}" /t REG_DWORD /d 1 /f | Out-Host
 
+# STEP 3C: Disable Windows Spotlight as per https://github.com/mtniehaus/AutopilotBranding/issues/13#issuecomment-2449224828
+Log "Disabling Windows Spotlight for Desktop"
+reg.exe add "HKLM\TempUser\Software\Policies\Microsoft\Windows\CloudContent" /v DisableSpotlightCollectionOnDesktop /t REG_DWORD /d 1 /f | Out-Host
+
 reg.exe unload HKLM\TempUser | Out-Host
 
 # STEP 3: Set time zone (if specified)

--- a/AutopilotBranding/Config.xml
+++ b/AutopilotBranding/Config.xml
@@ -42,6 +42,18 @@
     -->
     <Feature>WMIC</Feature>
   </AddFeatures>
+  <!-- This section defines a list of Optional Features to disable. Add the Name of the feature as returned by Get-WindowsOptionalFeature -->
+  <DisableOptionalFeatures>
+    <Feature>MicrosoftWindowsPowershellV2Root</Feature>
+    <Feature>WorkFolders-Client</Feature>
+    <Feature>Recall</Feature>
+    <Feature>MediaPlayback</Feature>
+  </DisableOptionalFeatures>
+  <!-- This section defines a list of Windows Capabilities to remove. Provide the name of the Capability to have it removed as returned by Get-WindowsCapability, excluding the tildes and version.  -->
+  <RemoveCapability>
+    <Capability>App.StepsRecorder</Capability>
+    <Capability>Microsoft.Windows.PowerShell.ISE</Capability>
+  </RemoveCapability>
   <Language></Language>
   <!-- If you want to set a language, customize and reference this file: <Language>Language.xml</Language> -->
   <DefaultApps>Associations.xml</DefaultApps>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ These customizations are currently supported:
 - Disable the Edge desktop icon.  When using OneDrive Known Folder Move, this can cause duplicate (and unnecessary) shortcuts to be synced.
 - Install language packs.  You can embed language pack CAB files into the MSI (place them into the LPs folder), and each will be automatically installed.  (In a perfect world, these would be pulled from Windows Update, but there's no simple way to do that, hence the need to include these in the MSI.  You can download the language pack ISO from MSDN or VLSC.)
 - Install features on demand (FOD).  Specify a list of features that you want to install, from the list at https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/features-on-demand-non-language-fod.  The needed components will be downloaded from Windows Update automatically and added to the running OS.
+- Remove features on demand (FOD). Specify a list of preinstalled Features on Demand to remove by their Capability Name, excluding the tilde characters and version number. Capability Names can be retrieved by running  `Get-WindowsCapability -Online` 
+- Disable Optional Features. Specify a list of optional features to disable by per their Feature Name. Feature Names can be retrieved by running  `Get-WindowsOptionalFeature -Online`
 - Configure language settings.  Adding a language pack isn't enough - you have to tell Windows that you want it to be configured for all users.  This is done through an XML file fed to INTL.CPL; customize the file as needed.  (Note this is commented out by default in the Config.xml file.)
 - Configure default apps.  Import a list of file associations (as created by manually configuring the associations that you want and then using "DISM /Online /Export-DefaultAppAssociations:C:\Associations.xml" to export those settings) that should replace the default app associations.  (Note that even though an example is included from a customized Windows 10 1903 image, making IE 11 the default browser, you should replace this file with your own exported version.  Also, do not edit the file that you exported, e.g. to remove entries that you didn't change.)
 
@@ -45,9 +47,10 @@ See https://oofhours.com/2020/05/18/two-for-one-updated-autopilot-branding-and-u
 
 ## Change history
 
-2023-09-23: Added logic to handle the Windows 11 Start menu proces using Start2.bin; Windows 10 will continue to use Layout.xml.  Added additional Windows 11 in-box apps to remove.
-2024-01-31: Added additional apps to remove, adding timestamps to log messages, cleaned up error logging.
-2024-04-27: Added logic to stop the Start menu from popping up each time a new user signs in.
+- 2023-09-23: Added logic to handle the Windows 11 Start menu proces using Start2.bin; Windows 10 will continue to use Layout.xml.  Added additional Windows 11 in-box apps to remove.
+- 2024-01-31: Added additional apps to remove, adding timestamps to log messages, cleaned up error logging.
+- 2024-04-27: Added logic to stop the Start menu from popping up each time a new user signs in.
+- 2024-12-26: Added support for removing FODs and disabling optional features.
 
 ## Suggestions?
 


### PR DESCRIPTION
Hi All, I have started working on building up a 24H2 environment and needed to add some extra functionality to support my scenario. Contibuting back the changes as I think others may find these useful

Added new functionality:

- Disable Windows Spotlight to ensure background will still apply on Windows 11 24H2 as per #13
- Added ability to Windows Optional Features to be disabled. Useful for removing Powershell 2.0 in environments that have that requirement
- Added ability to list Windows Capabilities to be removed. Useful for removing deprecated features if they are no longer required in your environment