### PR TITLE
Add check for Nuget

### DIFF
--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -412,6 +412,7 @@ if ($config.Config.SkipUpdates -ine "true") {
 [GC]::Collect()
 reg.exe unload HKLM\TempUser | Out-Host
 
+Log "AutoPilot Branding Completed"
 Write-Host "All done!"
 
 Stop-Transcript

--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -375,10 +375,29 @@ if ($config.Config.SkipAPv2 -ine "true") {
 # STEP 20: Try to get Windows to update stuff
 if ($config.Config.SkipUpdates -ine "true") {
 	try {
-		Log "Updating in-box apps"
+		Log "Check for Nuget Package"
+		$requiredVersion = [version]'2.8.5.201'
+		$providerName = "NuGet"
+		$packageProvider = Get-PackageProvider -Name $providerName -ListAvailable -ErrorAction SilentlyContinue | out-Null
+		if ($packageProvider -ne $null) {
+   		 	# Now try getting the installed version specifically
+		 	Log "NuGet Found, checking Version"
+			 $installedVersion = $packageProvider.Version
+		 if ($installedVersion -ge $requiredVersion) {
+        	Log "Nuget Meets requirements."
+    	} else {
+       	 	Log "Nuget Needs Update"
+			Install-PackageProvider -Name $providerName -Force | Out-Null
+   	    }
+    	} 
+		else {
+    		Log "Nuget Package Missing. Installing.."
+			Install-PackageProvider -Name $providerName -Force | Out-Null
+		}
+		Log "Install Update Inbox-App Script"
 		Install-Script Update-InboxApp -Force
+		Log "Updating Inbox-Apps"
 		Get-AppxPackage | Select-Object -Unique PackageFamilyName | Update-InboxApp.ps1
-
 		Log "Kicking off a Windows Update scan"
 		$Namespace = "Root\cimv2\mdm\dmmap"
 		$ClassName = "MDM_EnterpriseModernAppManagement_AppManagement01"


### PR DESCRIPTION
# Leaving Pull as reference to for New Pull Request #31 
The PS Gallery  [Update-InboxApp](https://www.powershellgallery.com/packages/Update-InboxApp/) will fail to install if NuGet is not already updated to a minimum version of 2.8.5.201

- This was observed in my testing #30 

Create new Logic in Step 20 to check for NuGet Package. If not installed will download and install it so that Inbox-Apps can be updated.

When NuGet not installed, the script is stopped waiting for user intervention to allow the update of Nuget and PowershellGet module.

![Nuget Error](https://github.com/user-attachments/assets/36acff68-e638-491f-9101-8507f1263f8d)
