### PR TITLE
Stop the transcript before exiting when not in OOBE

### DIFF
--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -123,6 +123,7 @@ if ($IsOOBEComplete) {
 	if (-not $Force)
 	{
 		Log "OOBE is completed, bailing out without doing any configuration."
+  		Stop-Transcript
 		exit 0
 	} else {
 		Log "OOBE is completed but -Force specified, will run anyway."


### PR DESCRIPTION
Add Stop-Transcript before exiting the script outside OOBE. Will avoid a system error...