### PR TITLE
Correct path for initial_preferences

### DIFF
--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -560,7 +560,7 @@ try
 		{
 			MkDir $dest -Force | Out-Null
 		}
-		Copy-Item ".\initial_preferences" "$dest\" -Force
+		Copy-Item "$($installFolder)initial_preferences" "$dest\" -Force
 		if (Test-Path "C:\Users\Public\Desktop\Google Chrome.lnk") {
 			Log "Removing Chrome desktop shortcut"
 			Remove-Item "C:\Users\Public\Desktop\Google Chrome.lnk" -Force


### PR DESCRIPTION
use existing variable $($installFolder) for the location of initial_preferences file. Avoid error based on the context of execution