### PR TITLE
Minor bugfixes

### DIFF
--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -376,9 +376,11 @@ try
 	}
 
 	# STEP 9: Add language packs
-	Get-ChildItem "$($installFolder)LPs" -Filter *.cab | ForEach-Object {
-		Log "Adding language pack: $($_.FullName)"
-		Add-WindowsPackage -Online -NoRestart -PackagePath $_.FullName
+	if (Test-Path "$($installFolder)LPs") {
+		Get-ChildItem "$($installFolder)LPs" -Filter *.cab | ForEach-Object {
+			Log "Adding language pack: $($_.FullName)"
+			Add-WindowsPackage -Online -NoRestart -PackagePath $_.FullName
+		}
 	}
 
 	# STEP 10: Change language


### PR DESCRIPTION
Hi Michael, & all,

I am submitting fixes for two minor issues we've encountered when deploying the package across our devices.

1. When `SkipTheme` configuration value is set to `true`, but `SkipLockScreen` is `false` - i.e. I only want my custom lockscreen image but keep the default theme - script fails to copy the image due to the destination folder missing. `Mkdir` is only called in Theme block but not in LockScreen, so I just added the same under LockScreen block.

2. We don't preinstall language packs on the machines, hence don't package `LPs` folder together with the package. This currently causes script to log an error as `Get-ChildItem` cmdlet is ran on a non-existent directory. It doesn't break the script, just annoys you when you look at the log. I added `Test-Path` around this so it doesn't try to enumerate the files if the folder does not exist.

Thanks
Vlad