### PR TITLE
Unload Default User Hive Earlier

### DIFF
--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -140,6 +140,7 @@ try
 	[Xml]$config = Get-Content "$($installFolder)Config.xml"
 
 	# PREP: Load the default user registry
+	Log "Loading Defualt User Registry Hive NTUSER.DAT"
 	reg.exe load HKLM\TempUser "C:\Users\Default\NTUSER.DAT" | Out-Null
 
 	# STEP 1: Apply a custom start menu and taskbar layout
@@ -596,6 +597,11 @@ try
 		Log 'Skipping APv2 tweaks'
 	}
 
+	# CLEANUP: Unload default user registry
+	Log "Unloading Default user Registry"
+	[GC]::Collect()
+	reg.exe unload HKLM\TempUser | Out-Null
+	
 	# STEP 20: Updates & Inbox-App script
 	if ($config.Config.SkipUpdates -ne 'true') {
 		try {
@@ -630,6 +636,7 @@ try
 
 	# STEP 21: Skip FSIA and turn off delayed desktop switch
 	if ($config.Config.SkipShowDesktopFaster -ine "true") {
+		Log "Skipping FSIA and turning off delayed desktop switch"
 		$registryPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
 		New-ItemProperty -Path $registryPath -Name "EnableFirstLogonAnimation" -Value 0 -PropertyType DWord -Force | Out-Null
 		New-ItemProperty -Path $registryPath -Name "DelayedDesktopSwitchTimeout" -Value 0 -PropertyType DWord -Force | Out-Null
@@ -637,9 +644,7 @@ try
 } catch {
 	Log "Unhandled exception: $_"
 } finally {
-	# CLEANUP: Unload default user registry
-	[GC]::Collect()
-	reg.exe unload HKLM\TempUser | Out-Null
+Log "All Steps Completed"
 }
 
 $stopUtc = [datetime]::UtcNow


### PR DESCRIPTION
Move Default User Unload process before the update Apps script runs. This will ensure the registry hive is cleanly closed incase the updating of Inbox-Apps fails or the script fails unexpectedly. As seen in the error below. The Script fails and exits before ever reaching the "finally" statement. Leaving the Default profile in a corrupt state.
``` 
} finally {
	# CLEANUP: Unload default user registry
	[GC]::Collect()
	reg.exe unload HKLM\TempUser | Out-Null
}
```

<img width="466" height="101" alt="image" src="https://github.com/user-attachments/assets/01844fce-3e01-4e06-ab3b-cb73bf20f18e" />


- As show issue #60 
- Added logging for loading and unloading the default user registry, as well as the skipping FSIA section, to be inline with the logging of other steps in the script.