### PR TITLE
Set search bar to icon only

### DIFF
--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -269,6 +269,14 @@ try
 		Set-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Dsh"  -Name "AllowNewsAndInterests" -Value 0
 
 	}
+	# STEP 4C: Set Search Bar to Icon Only via RunOnce
+	if ($config.Config.SkipSetSearchIcon -ine "true") {
+
+ 	Log "Setting Searchbar Icon via RunOnce"
+	& reg.exe add "HKLM\TempUser\Software\Microsoft\Windows\CurrentVersion\RunOnce" /f | Out-Null # Ensure path exists
+	$RunOnceCommand = 'reg add HKCU\Software\Microsoft\Windows\CurrentVersion\Search /t REG_DWORD /v SearchboxTaskbarMode /d 1 /f'
+	& reg.exe add "HKLM\TempUser\Software\Microsoft\Windows\CurrentVersion\RunOnce" /v 'SetSearchIconOnly' /t REG_SZ /d $RunOnceCommand /f | Out-Null
+	}
 
 	# STEP 5: Set time zone (if specified)
 	if ($config.Config.TimeZone) {

--- a/AutopilotBranding/Config.xml
+++ b/AutopilotBranding/Config.xml
@@ -18,7 +18,7 @@
    <!-- Only set 'SkipDisableWidgets' to false if you want to completely disable Widgets-->
   <SkipDisableWidgets>true</SkipDisableWidgets> 
   <SkipChromeConfig>false</SkipChromeConfig>
-  
+  <SkipSetSearchIcon>false</SkipSetSearchIcon>
   <!-- Settings for various items-->
   <TimeZone></TimeZone>
   <RemoveApps>


### PR DESCRIPTION
Set the Search Bar to the Icon only. Sets its the default by running a run once command on first login but it does not disable or grey out the setting to restore the Search Box if user wants to (Unlike  the Intune polices)

<img width="100" height="63" alt="image" src="https://github.com/user-attachments/assets/9243de82-7bf7-4e50-86a3-dc12dfe5f0d5" />
