### PR TITLE
Add Ability to remove Office C2Rs

### DIFF
--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -269,6 +269,14 @@ try
 		Set-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Dsh"  -Name "AllowNewsAndInterests" -Value 0
 
 	}
+	# STEP 4C: Set Search Bar to Icon Only via RunOnce
+	if ($config.Config.SkipSetSearchIcon -ine "true") {
+
+ 	Log "Setting Searchbar Icon via RunOnce"
+	& reg.exe add "HKLM\TempUser\Software\Microsoft\Windows\CurrentVersion\RunOnce" /f | Out-Null # Ensure path exists
+	$RunOnceCommand = 'reg add HKCU\Software\Microsoft\Windows\CurrentVersion\Search /t REG_DWORD /v SearchboxTaskbarMode /d 1 /f'
+	& reg.exe add "HKLM\TempUser\Software\Microsoft\Windows\CurrentVersion\RunOnce" /v 'SetSearchIconOnly' /t REG_SZ /d $RunOnceCommand /f | Out-Null
+	}
 
 	# STEP 5: Set time zone (if specified)
 	if ($config.Config.TimeZone) {

--- a/AutopilotBranding/AutopilotBranding.ps1
+++ b/AutopilotBranding/AutopilotBranding.ps1
@@ -691,6 +691,48 @@ try
 		New-ItemProperty -Path $registryPath -Name "EnableFirstLogonAnimation" -Value 0 -PropertyType DWord -Force | Out-Null
 		New-ItemProperty -Path $registryPath -Name "DelayedDesktopSwitchTimeout" -Value 0 -PropertyType DWord -Force | Out-Null
 	}
+	# STEP 22: Remove All Office Products
+	## Remove All Office Products
+	if ($config.Config.SkipRemoveOffice -ine "true") {
+	Log  "Remove All Office Products Selected"
+	
+## The XML below will Remove All Microsoft C2Rs ( Click-to-Runs), regardless of Product ID and Languages. To remove All Comment out or remove the XML block between Start and End above. Then Uncomment the XML below.
+$xml = @"
+<Configuration>
+  <Display Level="None" AcceptEULA="True" />
+  <Property Name="FORCEAPPSHUTDOWN" Value="True" />
+  <Remove All="TRUE">
+  </Remove>
+  <RemoveMSI />
+</Configuration>
+"@
+## Remove All Office Products XML End ##
+
+	# Define temp folder and file paths
+	$tempFolder     = $env:TEMP
+	$xmlPath        = Join-Path $tempFolder 'o365.xml'
+	$odtPath        = Join-Path $tempFolder 'setup.exe'
+
+	# Write XML to temp folder
+	$xml | Out-File -FilePath $xmlPath -Encoding UTF8
+	Log "Downloading lastet ODT"
+	# Download the Latest ODT into temp folder. URI obtained from Stealthpuppy's Evergreen Project
+	$odtUrl = 'https://officecdn.microsoft.com/pr/wsus/setup.exe'
+	Invoke-WebRequest -Uri $odtUrl `
+                  -OutFile $odtPath `
+                  -UseBasicParsing
+
+	Log "Running ODT"
+	# Run the ODT from temp, pointing at the XML also in temp
+	$proc = Start-Process -FilePath $odtPath `
+              -ArgumentList "/configure `"$xmlPath`"" `
+              -WindowStyle Hidden `
+              -Wait `
+              -PassThru
+	$proc | Wait-Process
+	Log "ODT exit code: $($proc.ExitCode)"	
+	} 
+	
 } catch {
 	Log "Unhandled exception: $_"
 } finally {

--- a/AutopilotBranding/Config.xml
+++ b/AutopilotBranding/Config.xml
@@ -18,7 +18,7 @@
    <!-- Only set 'SkipDisableWidgets' to false if you want to completely disable Widgets-->
   <SkipDisableWidgets>true</SkipDisableWidgets> 
   <SkipChromeConfig>false</SkipChromeConfig>
-  
+  <SkipSetSearchIcon>false</SkipSetSearchIcon>
   <!-- Settings for various items-->
   <TimeZone></TimeZone>
   <RemoveApps>

--- a/AutopilotBranding/Config.xml
+++ b/AutopilotBranding/Config.xml
@@ -18,7 +18,7 @@
    <!-- Only set 'SkipDisableWidgets' to false if you want to completely disable Widgets-->
   <SkipDisableWidgets>true</SkipDisableWidgets> 
   <SkipChromeConfig>false</SkipChromeConfig>
-  
+  <SkipRemoveOffice>false</SkipRemoveOffice>
   <!-- Settings for various items-->
   <TimeZone></TimeZone>
   <RemoveApps>

--- a/AutopilotBranding/Config.xml
+++ b/AutopilotBranding/Config.xml
@@ -57,6 +57,7 @@
     <App>MicrosoftCorporationII.MicrosoftFamily</App>
     <App>MicrosoftTeams</App>
     <App>MSTeams</App>
+    <App>Microsoft.M365Companions</App>
     <!-- Microsoft Copilot -->
     <App>9NHT9RB2F4HD</App>
   </RemoveApps>


### PR DESCRIPTION
### Feature to Remove OEM all Office 365 C2Rs from any language.

Came across a scenario where re-installing the Cloud Restore Media from HP installed a insane amount of  Click-toRuns in multiple Languages..
<img width="928" height="664" alt="Office Installers" src="https://github.com/user-attachments/assets/9fda1f95-3ebd-411a-9c2d-03349e239d87" />



- Add the ability to Pull down the latest MS 365 ODT tool and remove all OEM Office Apps found using a defined .xml with:
`<Remove All="TRUE"/> `

- Enable the Flag in the  config.xml to remove them. 
-  set to `<SkipRemoveOffice>false</SkipRemoveOffice>` as default

_note:  the remove all should only remove all core Office Apps and the old OneDrive (Groove) client. Modern OneDrive sync is separate and should remain if updated previously in the script steps._